### PR TITLE
Add function to insert meshblock data into a global array

### DIFF
--- a/athplot/image.py
+++ b/athplot/image.py
@@ -45,10 +45,10 @@ class Image:
       if self.extent[1] < block_extent[0] or self.extent[0] > block_extent[1] \
         or self.extent[3] < block_extent[2] or self.extent[2] > block_extent[3]:
         continue
-      block_xs, block_ys = block.get_coord_blocks()
+      block_ys, block_xs = block.get_coord_blocks()
       xpoints = np.append(xpoints, block_xs.flatten(order='C'))
       ypoints = np.append(ypoints, block_ys.flatten(order='C'))
-      data = np.append(data, block_data.T.flatten(order='C'))
+      data = np.append(data, block_data.flatten(order='C'))
     
     self.xpoints = xpoints
     self.ypoints = ypoints

--- a/athplot/load_ath_bin.py
+++ b/athplot/load_ath_bin.py
@@ -276,7 +276,7 @@ class MeshBlock:
   def get_coord_blocks(self):
     if self.is_2d():
       x, y = self.get_coords()
-      return np.meshgrid(x, y, indexing='ij')
+      return np.meshgrid(y, x, indexing='ij')
     else:
       x, y, z = self.get_coords()
       return np.meshgrid(z, y, x, indexing='ij')
@@ -333,6 +333,22 @@ class MeshBlock:
 
   def is_2d(self):
     return (self.size[0] == 1) or (self.size[1] == 1) or (self.size[2] == 1)
+
+  def restrict(self):
+    """Returns a slice of a global array that contains only this block
+
+    NOTE. This currently works only for unigrid and assumes that ghost zones
+    are not included in the output.
+    """
+    sl = []
+    ijk = [self.i, self.j, self.k]
+    for d in [2,1,0]:
+      if self.size[d] == 1:
+        sl.append(slice(0, 1))
+      else:
+        sl.append(slice(ijk[d]*self.size[d],
+                        ijk[d]*self.size[d] + self.size[d]))
+    return tuple(sl)
 
 class MeshBlockSlice:
   def __init__(self, meshblock, slice_loc):


### PR DESCRIPTION
This currently works only in unigrid. It should be possible to extend this to work for mesh refinement by taking into account the level of each block and returning a trivial slicing for blocks at at a level other than that being filled.

This also makes the way coordinate arrays are returned consistent with the underlying indexing of the data.